### PR TITLE
fix: imports after introducing astro 5.19 dependency

### DIFF
--- a/src/utils/strapi.ts
+++ b/src/utils/strapi.ts
@@ -1,4 +1,5 @@
-import { z, defineCollection, CollectionConfig } from "astro:content";
+import { z, defineCollection } from "astro:content";
+import type { CollectionConfig } from "astro/content/config";
 
 import type { StrapiComponent, StrapiContentType, StrapiResponse } from "../types/strapi";
 import { StrapiSchemaGenerator } from "./schema";


### PR DESCRIPTION
# Pull Request

## 📝 Description
Fix the `CollectionConfig` import after introducing the dependency to Astro 5.19+

## 🔄 Changes
Changed import source.

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My changes follow the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] I have added my changes to the [CHANGELOG.md](CHANGELOG.md)