### PR TITLE
feat: native Markdown rendering (Astro renderMarkdown)

### DIFF
--- a/.ai/astro-strapi-loader/SKILL.md
+++ b/.ai/astro-strapi-loader/SKILL.md
@@ -142,6 +142,17 @@ The same `StrapiCollection` shape applies; routing is defined by the content typ
 - `getEntry('key', 'locale:documentId' | 'locale:slug')` when using prefixed ids.
 - **Runtime** Strapi calls: `fetchContent` with **`qs.stringify`’d** params, ideally reusing the **same** query object as build time.
 
+### Native Markdown (`render()` / `<Content />`)
+
+Opt-in via `markdown` on the collection / `strapiLoader` options (omit = unchanged behavior):
+
+- `field`: dot-path to a markdown string
+- `getMarkdown`: custom extractor (wins over `field`)
+- `format: "html"` for already-rendered HTML; default `"markdown"` uses Astro `renderMarkdown()`
+- Helpers: `getValueByPath`, `resolveMarkdownSource`, `createHtmlRenderedContent`, `buildEntryRenderedContent`
+
+Not for Strapi Blocks JSON — only string Markdown/HTML fields.
+
 ## Troubleshooting
 
 - **Empty or partial data:** `populate` depth, wrong `locale`, draft/unpublished, or `filters` too strict.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-07-26
+
+### Added
+
+- **Native Markdown rendering** (opt-in) — `markdown` on `StrapiLoaderOptions` / `StrapiCollection` uses Astro `LoaderContext.renderMarkdown()` so `render()` / `<Content />` inherit the project markdown config (#6).
+  - `field` (dot-path) and `getMarkdown` extractor
+  - `includeBody` (default `true`) and `format: "markdown" | "html"`
+  - Helpers: `getValueByPath`, `resolveMarkdownSource`, `createHtmlRenderedContent`, `buildEntryRenderedContent`
+- Unit tests for markdown helpers and loader integration (including locales).
+
+### Changed
+
+- Base load path is unchanged when `markdown` is omitted.
+
 ## [1.4.0] - 2026-07-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ yarn add @sensinum/astro-strapi-loader
 * **🆕 Custom ID generation** - Generate collection IDs from custom fields (e.g., slugs)
 * **🆕 Multiple collections** - Create multiple collections from same endpoint
 * **🆕 i18n support** - Built-in locale support for multilingual content
+* **🆕 Native Markdown** - Opt-in `markdown` option uses Astro `renderMarkdown()` so `render()` / `<Content />` inherit your project markdown config (closes [#6](https://github.com/VirtusLab-Open-Source/astro-strapi-loader/issues/6))
 
 ## 🤖 AI-native support
 
@@ -156,6 +157,7 @@ const myCollection = await fetchContent({
 | `collectionName` | `string` | No | Custom collection name (for multiple collections from same endpoint) |
 | `idGenerator` | `function` | No | Custom function to generate IDs from item data |
 | `locale` | `string \| string[]` | No | Single locale or array of locales for i18n support |
+| `markdown` | `StrapiMarkdownOptions` | No | Opt-in body rendering for Astro `render()` (see [Native Markdown](#native-markdown)) |
 | `headers` | `Record<string, string>` | No | Additional headers for API request |
 
 > **⚠️ Note:** The token must have **read access** to both the **Content API** and the **Content-Type Builder API** *(ONLY to the "Get Content Types" endpoint)*.
@@ -353,6 +355,59 @@ const blogMultilang = defineCollection({
 
 // Access: getEntry('blogAllLanguages', 'en:my-post-slug')
 ```
+
+#### Native Markdown
+
+Opt-in support for Astro’s Content Layer `render()` / `<Content />`, using the same markdown pipeline as local `.md` files ([Loader `renderMarkdown`](https://docs.astro.build/en/reference/content-loader-reference/)). When `markdown` is omitted, the loader behavior is unchanged.
+
+**`StrapiMarkdownOptions`**
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `field` | `string` | — | Dot-path to a markdown string on the entry (e.g. `content`, `seo.description`) |
+| `getMarkdown` | `(data) => string \| null \| undefined \| Promise<…>` | — | Custom extractor (wins over `field`) |
+| `includeBody` | `boolean` | `true` | Also store raw source on `entry.body` |
+| `format` | `"markdown" \| "html"` | `"markdown"` | `markdown` → `renderMarkdown()`; `html` → pass-through for already-rendered HTML |
+
+Helpers exported from the package: `getValueByPath`, `resolveMarkdownSource`, `createHtmlRenderedContent`, `buildEntryRenderedContent`.
+
+**With `generateCollections`:**
+
+```typescript
+strapiCollections = await generateCollections({
+  url: import.meta.env.STRAPI_URL,
+  token: import.meta.env.STRAPI_TOKEN,
+}, [{
+  name: "articles",
+  idGenerator: (data) => data.slug as string,
+  markdown: { field: "content" },
+  query: { populate: { seo: true } },
+}]);
+```
+
+**With `getMarkdown` (compose / nested fields):**
+
+```typescript
+markdown: {
+  getMarkdown: (data) => {
+    const blocks = data.sections as Array<{ body?: string }> | undefined;
+    return blocks?.map((b) => b.body).filter(Boolean).join("\n\n");
+  },
+}
+```
+
+**In a page:**
+
+```astro
+---
+import { getEntry, render } from 'astro:content';
+const entry = await getEntry('articles', Astro.params.slug);
+const { Content } = await render(entry);
+---
+<Content />
+```
+
+> **Note:** This targets **string Markdown** (or HTML with `format: "html"`). Strapi **Blocks** remain a separate concern (e.g. a blocks renderer package).
 
 ### Query Options
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensinum/astro-strapi-loader",
-  "version": "1.5.0",
+  "version": "1.5.0-beta.1",
   "description": "Astro loader for Strapi CMS",
   "keywords": [
     "astro",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sensinum/astro-strapi-loader",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Astro loader for Strapi CMS",
   "keywords": [
     "astro",

--- a/src/utils/__tests__/loader-extended.test.ts
+++ b/src/utils/__tests__/loader-extended.test.ts
@@ -420,5 +420,103 @@ describe("strapiLoader - Extended Features", () => {
       });
     });
   });
+
+  describe("Native Markdown rendering", () => {
+    const renderMarkdown = jest.fn(async (content: string) => ({
+      html: `<article>${content}</article>`,
+    }));
+
+    beforeEach(() => {
+      renderMarkdown.mockClear();
+      (mockContext as any).renderMarkdown = renderMarkdown;
+    });
+
+    it("does not call renderMarkdown when markdown option is omitted", async () => {
+      (fetchContent as jest.Mock).mockResolvedValueOnce({
+        data: [{ documentId: "1", content: "# Hi" }],
+      });
+
+      const loader = strapiLoader("posts", options);
+      await loader.load(mockContext as unknown as LoaderContext);
+
+      expect(renderMarkdown).not.toHaveBeenCalled();
+      expect(mockContext.store.set).toHaveBeenCalledWith({
+        id: "1",
+        data: { documentId: "1", content: "# Hi" },
+        digest: "test-digest",
+      });
+    });
+
+    it("stores body + rendered from field via Astro renderMarkdown", async () => {
+      (fetchContent as jest.Mock).mockResolvedValueOnce({
+        data: [{ documentId: "1", content: "# Hello" }],
+      });
+
+      const loader = strapiLoader("posts", {
+        ...options,
+        markdown: { field: "content" },
+      });
+      await loader.load(mockContext as unknown as LoaderContext);
+
+      expect(renderMarkdown).toHaveBeenCalledWith("# Hello");
+      expect(mockContext.store.set).toHaveBeenCalledWith({
+        id: "1",
+        data: { documentId: "1", content: "# Hello" },
+        digest: "test-digest",
+        body: "# Hello",
+        rendered: { html: "<article># Hello</article>" },
+      });
+    });
+
+    it("uses getMarkdown and works with locales", async () => {
+      (fetchContent as jest.Mock)
+        .mockResolvedValueOnce({
+          data: [{ documentId: "1", title: "EN", content: "Body EN" }],
+        })
+        .mockResolvedValueOnce({
+          data: [{ documentId: "1", title: "DE", content: "Body DE" }],
+        });
+
+      const loader = strapiLoader("posts", {
+        ...options,
+        locale: ["en", "de"],
+        markdown: {
+          getMarkdown: (data) => `# ${data.title}\n\n${data.content}`,
+        },
+      });
+      await loader.load(mockContext as unknown as LoaderContext);
+
+      expect(renderMarkdown).toHaveBeenCalledWith("# EN\n\nBody EN");
+      expect(renderMarkdown).toHaveBeenCalledWith("# DE\n\nBody DE");
+      expect(mockContext.store.set).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: "en:1",
+          body: "# EN\n\nBody EN",
+          rendered: { html: "<article># EN\n\nBody EN</article>" },
+        }),
+      );
+    });
+
+    it("supports format html without calling renderMarkdown", async () => {
+      (fetchContent as jest.Mock).mockResolvedValueOnce({
+        data: [{ documentId: "1", html: "<p>raw</p>" }],
+      });
+
+      const loader = strapiLoader("posts", {
+        ...options,
+        markdown: { field: "html", format: "html" },
+      });
+      await loader.load(mockContext as unknown as LoaderContext);
+
+      expect(renderMarkdown).not.toHaveBeenCalled();
+      expect(mockContext.store.set).toHaveBeenCalledWith({
+        id: "1",
+        data: { documentId: "1", html: "<p>raw</p>" },
+        digest: "test-digest",
+        body: "<p>raw</p>",
+        rendered: { html: "<p>raw</p>" },
+      });
+    });
+  });
 });
 

--- a/src/utils/__tests__/markdown.test.ts
+++ b/src/utils/__tests__/markdown.test.ts
@@ -1,0 +1,150 @@
+import {
+  buildEntryRenderedContent,
+  createHtmlRenderedContent,
+  getValueByPath,
+  resolveMarkdownSource,
+  type StrapiMarkdownOptions,
+} from "../markdown";
+
+describe("markdown helpers", () => {
+  describe("getValueByPath", () => {
+    it("reads nested dot paths", () => {
+      const data = { seo: { description: "hello" }, title: "t" };
+      expect(getValueByPath(data, "seo.description")).toBe("hello");
+      expect(getValueByPath(data, "title")).toBe("t");
+    });
+
+    it("returns undefined for missing paths", () => {
+      expect(getValueByPath({}, "a.b")).toBeUndefined();
+      expect(getValueByPath({ a: 1 }, "a.b")).toBeUndefined();
+    });
+  });
+
+  describe("resolveMarkdownSource", () => {
+    it("uses field path", async () => {
+      const source = await resolveMarkdownSource(
+        { content: "# Hi" },
+        { field: "content" },
+      );
+      expect(source).toBe("# Hi");
+    });
+
+    it("prefers getMarkdown over field", async () => {
+      const source = await resolveMarkdownSource(
+        { content: "# from-field", body: "# from-body" },
+        {
+          field: "content",
+          getMarkdown: (data) => data.body as string,
+        },
+      );
+      expect(source).toBe("# from-body");
+    });
+
+    it("supports async getMarkdown", async () => {
+      const source = await resolveMarkdownSource(
+        { content: "x" },
+        {
+          getMarkdown: async (data) => `async:${data.content}`,
+        },
+      );
+      expect(source).toBe("async:x");
+    });
+
+    it("skips empty / non-string values", async () => {
+      expect(
+        await resolveMarkdownSource({ content: "   " }, { field: "content" }),
+      ).toBeUndefined();
+      expect(
+        await resolveMarkdownSource({ content: 123 }, { field: "content" }),
+      ).toBeUndefined();
+      expect(
+        await resolveMarkdownSource(
+          { content: "x" },
+          { getMarkdown: () => null },
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe("createHtmlRenderedContent", () => {
+    it("builds rendered payload", () => {
+      expect(createHtmlRenderedContent("<p>Hi</p>")).toEqual({
+        html: "<p>Hi</p>",
+      });
+      expect(
+        createHtmlRenderedContent("<p>Hi</p>", { frontmatter: { a: 1 } }),
+      ).toEqual({
+        html: "<p>Hi</p>",
+        metadata: { frontmatter: { a: 1 } },
+      });
+    });
+  });
+
+  describe("buildEntryRenderedContent", () => {
+    const renderMarkdown = jest.fn(async (content: string) => ({
+      html: `<p>${content}</p>`,
+      metadata: { headings: [] },
+    }));
+
+    beforeEach(() => {
+      renderMarkdown.mockClear();
+    });
+
+    it("returns empty object when markdown option is omitted", async () => {
+      await expect(
+        buildEntryRenderedContent({ content: "# x" }, undefined, renderMarkdown),
+      ).resolves.toEqual({});
+      expect(renderMarkdown).not.toHaveBeenCalled();
+    });
+
+    it("renders markdown via renderMarkdown and includes body by default", async () => {
+      const result = await buildEntryRenderedContent(
+        { content: "# Hello" },
+        { field: "content" },
+        renderMarkdown,
+      );
+      expect(renderMarkdown).toHaveBeenCalledWith("# Hello");
+      expect(result).toEqual({
+        body: "# Hello",
+        rendered: { html: "<p># Hello</p>", metadata: { headings: [] } },
+      });
+    });
+
+    it("can omit body", async () => {
+      const result = await buildEntryRenderedContent(
+        { content: "# Hello" },
+        { field: "content", includeBody: false },
+        renderMarkdown,
+      );
+      expect(result.body).toBeUndefined();
+      expect(result.rendered).toBeDefined();
+    });
+
+    it("passes HTML through without calling renderMarkdown", async () => {
+      const result = await buildEntryRenderedContent(
+        { html: "<strong>x</strong>" },
+        { field: "html", format: "html" },
+        renderMarkdown,
+      );
+      expect(renderMarkdown).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        body: "<strong>x</strong>",
+        rendered: { html: "<strong>x</strong>" },
+      });
+    });
+
+    it("uses getMarkdown for composed sources", async () => {
+      const options: StrapiMarkdownOptions = {
+        getMarkdown: (data) =>
+          [`# ${data.title}`, data.content].filter(Boolean).join("\n\n"),
+      };
+      const result = await buildEntryRenderedContent(
+        { title: "Post", content: "Body" },
+        options,
+        renderMarkdown,
+      );
+      expect(renderMarkdown).toHaveBeenCalledWith("# Post\n\nBody");
+      expect(result.body).toBe("# Post\n\nBody");
+    });
+  });
+});

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./loader";
+export * from "./markdown";
 export * from "./schema";
 export * from "./strapi";

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -1,5 +1,9 @@
 import type { Loader, LoaderContext } from "astro/loaders";
 import qs from "qs";
+import {
+  buildEntryRenderedContent,
+  type StrapiMarkdownOptions,
+} from "./markdown";
 import { fetchContent } from "./strapi";
 
 export interface StrapiLoaderOptions {
@@ -22,7 +26,24 @@ export interface StrapiLoaderOptions {
    * - string[]: multiple locales (e.g., ['en', 'de']) - returns structure like { 'en': items, 'de': items }
    */
   locale?: string | string[];
+  /**
+   * Opt-in Markdown / HTML body rendering via Astro's Content Layer.
+   * When set, entries get `rendered` (and usually `body`) so `render()` / `<Content />` work
+   * with the project's markdown config. When omitted, behavior is unchanged.
+   */
+  markdown?: StrapiMarkdownOptions;
 }
+
+type StoreHelpers = {
+  store: LoaderContext["store"];
+  logger: LoaderContext["logger"];
+  parseData: LoaderContext["parseData"];
+  generateDigest: LoaderContext["generateDigest"];
+  renderMarkdown?: LoaderContext["renderMarkdown"];
+  idGenerator?: (data: Record<string, unknown>) => string;
+  markdown?: StrapiMarkdownOptions;
+  collectionName: string;
+};
 
 export function strapiLoader(
   contentType: string,
@@ -32,13 +53,25 @@ export function strapiLoader(
   return ({
     name: options.collectionName || "strapi-loader",
     load: async (context: LoaderContext): Promise<void> => {
-      const { store, logger, parseData, generateDigest } = context;
+      const { store, logger, parseData, generateDigest, renderMarkdown } =
+        context;
       const collectionName = options.collectionName || contentType;
 
       logger.info(`[${collectionName}] Loading data from Strapi...`);
-      const { url, token, idGenerator, locale, headers } = options;
+      const { url, token, idGenerator, locale, headers, markdown } = options;
 
       store.clear();
+
+      const storeHelpers: StoreHelpers = {
+        store,
+        logger,
+        parseData,
+        generateDigest,
+        renderMarkdown,
+        idGenerator,
+        markdown,
+        collectionName,
+      };
 
       // Determine which locales to fetch
       const localesToFetch: string[] | undefined = locale
@@ -51,7 +84,7 @@ export function strapiLoader(
       if (!localesToFetch) {
         await fetchAndStoreData(
           { url, token, contentType, query, headers },
-          { store, logger, parseData, generateDigest, idGenerator, collectionName }
+          storeHelpers,
         );
       } else {
         // Fetch data for each locale separately
@@ -80,15 +113,51 @@ export function strapiLoader(
         }
 
         // Store data with locale structure
-        await storeLocaleData(
-          localeDataMap,
-          { store, parseData, generateDigest, idGenerator }
-        );
+        await storeLocaleData(localeDataMap, storeHelpers);
       }
 
       logger.info(`[${collectionName}] Loading data from Strapi... DONE`);
     },
   }) satisfies Loader;
+}
+
+async function storeParsedEntry(
+  item: Record<string, unknown>,
+  itemId: string,
+  helpers: StoreHelpers,
+): Promise<void> {
+  const {
+    store,
+    parseData,
+    generateDigest,
+    renderMarkdown,
+    markdown,
+  } = helpers;
+
+  const data = await parseData({
+    id: itemId,
+    data: item,
+  });
+
+  const { body, rendered } = await buildEntryRenderedContent(
+    data as Record<string, unknown>,
+    markdown,
+    renderMarkdown,
+  );
+
+  const digest = generateDigest(
+    rendered
+      ? { ...(data as Record<string, unknown>), __renderedHtml: rendered.html }
+      : (data as Record<string, unknown>),
+  );
+
+  store.set({
+    id: itemId,
+    data,
+    digest,
+    ...(body !== undefined ? { body } : {}),
+    ...(rendered !== undefined ? { rendered } : {}),
+  });
 }
 
 async function fetchAndStoreData(
@@ -99,17 +168,10 @@ async function fetchAndStoreData(
     query: Record<string, unknown>;
     headers?: Record<string, string>;
   },
-  storeOptions: {
-    store: LoaderContext['store'];
-    logger: LoaderContext['logger'];
-    parseData: LoaderContext['parseData'];
-    generateDigest: LoaderContext['generateDigest'];
-    idGenerator?: (data: Record<string, unknown>) => string;
-    collectionName: string;
-  }
+  storeHelpers: StoreHelpers,
 ): Promise<void> {
   const { url, token, contentType, query, headers } = fetchOptions;
-  const { store, logger, parseData, generateDigest, idGenerator, collectionName } = storeOptions;
+  const { logger, idGenerator, collectionName } = storeHelpers;
 
   const response = await fetchContent({
     url,
@@ -134,36 +196,23 @@ async function fetchAndStoreData(
   if (Array.isArray(response.data)) {
     await Promise.all(
       response.data.map(async (item: Record<string, unknown>) => {
-        const itemId = getItemId(item);
-        const data = await parseData({
-          id: itemId,
-          data: item,
-        });
-        const digest = generateDigest(data);
-        store.set({ id: itemId, data, digest });
+        await storeParsedEntry(item, getItemId(item), storeHelpers);
       }),
     );
   } else {
-    const itemId = getItemId(response.data);
-    const data = await parseData({
-      id: itemId,
-      data: response.data,
-    });
-    const digest = generateDigest(data);
-    store.set({ id: itemId, data, digest });
+    await storeParsedEntry(
+      response.data,
+      getItemId(response.data),
+      storeHelpers,
+    );
   }
 }
 
 async function storeLocaleData(
   localeDataMap: Record<string, any>,
-  storeOptions: {
-    store: LoaderContext['store'];
-    parseData: LoaderContext['parseData'];
-    generateDigest: LoaderContext['generateDigest'];
-    idGenerator?: (data: Record<string, unknown>) => string;
-  }
+  storeHelpers: StoreHelpers,
 ): Promise<void> {
-  const { store, parseData, generateDigest, idGenerator } = storeOptions;
+  const { idGenerator } = storeHelpers;
 
   const getItemId = (item: Record<string, unknown>, locale: string): string => {
     if (idGenerator) {
@@ -176,23 +225,19 @@ async function storeLocaleData(
     if (Array.isArray(data)) {
       await Promise.all(
         data.map(async (item: Record<string, unknown>) => {
-          const itemId = getItemId(item, locale);
-          const parsedData = await parseData({
-            id: itemId,
-            data: { ...item, _locale: locale },
-          });
-          const digest = generateDigest(parsedData);
-          store.set({ id: itemId, data: parsedData, digest });
+          await storeParsedEntry(
+            { ...item, _locale: locale },
+            getItemId(item, locale),
+            storeHelpers,
+          );
         }),
       );
     } else {
-      const itemId = getItemId(data, locale);
-      const parsedData = await parseData({
-        id: itemId,
-        data: { ...data, _locale: locale },
-      });
-      const digest = generateDigest(parsedData);
-      store.set({ id: itemId, data: parsedData, digest });
+      await storeParsedEntry(
+        { ...data, _locale: locale },
+        getItemId(data, locale),
+        storeHelpers,
+      );
     }
   }
 }

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -1,0 +1,148 @@
+/**
+ * Compatible with Astro Content Layer `DataEntry.rendered` /
+ * `LoaderContext.renderMarkdown()` return value.
+ */
+export interface StrapiRenderedContent {
+  html: string;
+  metadata?: {
+    imagePaths?: Array<string>;
+    headings?: Array<{ depth: number; slug: string; text: string }>;
+    frontmatter?: Record<string, any>;
+    [key: string]: unknown;
+  };
+}
+
+/**
+ * Options for rendering a Strapi markdown (or HTML) field through Astro's
+ * Content Layer so `render()` / `<Content />` work with the project's markdown config.
+ *
+ * Opt-in only — when omitted, the loader stores entries exactly as before.
+ */
+export interface StrapiMarkdownOptions {
+  /**
+   * Dot-path to a string field on the Strapi entry (e.g. `"content"`, `"seo.description"`).
+   * Used when {@link getMarkdown} is not provided.
+   */
+  field?: string;
+  /**
+   * Custom extractor for the markdown (or HTML) source. Takes precedence over {@link field}.
+   * Return `null` / `undefined` to skip rendering for that entry.
+   */
+  getMarkdown?: (
+    data: Record<string, unknown>,
+  ) =>
+    | string
+    | null
+    | undefined
+    | Promise<string | null | undefined>;
+  /**
+   * When `true` (default), also store the raw source on `entry.body`.
+   */
+  includeBody?: boolean;
+  /**
+   * How to treat the resolved source:
+   * - `"markdown"` (default): run Astro `renderMarkdown()` (inherits `astro.config` markdown settings).
+   * - `"html"`: pass through as already-rendered HTML (e.g. CKEditor output) without markdown processing.
+   */
+  format?: "markdown" | "html";
+}
+
+/**
+ * Read a nested value from an object using a dot-separated path.
+ */
+export function getValueByPath(
+  data: Record<string, unknown>,
+  path: string,
+): unknown {
+  if (!path) {
+    return undefined;
+  }
+  return path.split(".").reduce<unknown>((acc, key) => {
+    if (acc === null || acc === undefined || typeof acc !== "object") {
+      return undefined;
+    }
+    return (acc as Record<string, unknown>)[key];
+  }, data);
+}
+
+/**
+ * Resolve the markdown/HTML source string for an entry from {@link StrapiMarkdownOptions}.
+ * Returns `undefined` when there is nothing to render (keeps base loader flow unchanged).
+ */
+export async function resolveMarkdownSource(
+  data: Record<string, unknown>,
+  options: StrapiMarkdownOptions,
+): Promise<string | undefined> {
+  if (options.getMarkdown) {
+    const value = await options.getMarkdown(data);
+    return normalizeSource(value);
+  }
+
+  if (options.field) {
+    return normalizeSource(getValueByPath(data, options.field));
+  }
+
+  return undefined;
+}
+
+function normalizeSource(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  // Preserve original string for rendering (only reject empty/whitespace-only).
+  if (value.trim().length === 0) {
+    return undefined;
+  }
+  return value;
+}
+
+/**
+ * Build a rendered-content object from an HTML string for `store.set({ rendered })`.
+ * Use with `format: "html"` or when you already have HTML from Strapi.
+ */
+export function createHtmlRenderedContent(
+  html: string,
+  metadata?: StrapiRenderedContent["metadata"],
+): StrapiRenderedContent {
+  return metadata ? { html, metadata } : { html };
+}
+
+export type RenderMarkdownFn = (
+  content: string,
+  options?: { fileURL?: URL },
+) => Promise<StrapiRenderedContent>;
+
+/**
+ * Resolve source + produce `body` / `rendered` for a content entry.
+ * Returns empty fields when markdown options are absent or the source is empty.
+ */
+export async function buildEntryRenderedContent(
+  data: Record<string, unknown>,
+  markdown: StrapiMarkdownOptions | undefined,
+  renderMarkdown: RenderMarkdownFn | undefined,
+): Promise<{ body?: string; rendered?: StrapiRenderedContent }> {
+  if (!markdown) {
+    return {};
+  }
+
+  const source = await resolveMarkdownSource(data, markdown);
+  if (source === undefined) {
+    return {};
+  }
+
+  const includeBody = markdown.includeBody !== false;
+  const format = markdown.format ?? "markdown";
+
+  let rendered: StrapiRenderedContent | undefined;
+
+  if (format === "html") {
+    rendered = createHtmlRenderedContent(source);
+  } else if (renderMarkdown) {
+    rendered = await renderMarkdown(source);
+  }
+
+  return {
+    ...(includeBody ? { body: source } : {}),
+    ...(rendered ? { rendered } : {}),
+  };
+}

--- a/src/utils/strapi.ts
+++ b/src/utils/strapi.ts
@@ -5,6 +5,7 @@ import { z } from "astro/zod";
 import type { StrapiComponent, StrapiContentType, StrapiResponse } from "../types/strapi";
 import { StrapiSchemaGenerator } from "./schema";
 import { strapiLoader } from "./loader";
+import type { StrapiMarkdownOptions } from "./markdown";
 
 export interface StrapiRequestOptions {
   url: string;
@@ -38,6 +39,11 @@ export interface StrapiCollection {
    * - string[]: multiple locales (e.g., ['en', 'de']) - returns structure like { 'en': items, 'de': items }
    */
   locale?: string | string[];
+  /**
+   * Opt-in Markdown / HTML rendering for Astro `render()` / `<Content />`.
+   * See {@link StrapiMarkdownOptions}.
+   */
+  markdown?: StrapiMarkdownOptions;
 }
 
 async function strapiRequest<T>(options: StrapiRequestOptions): Promise<T> {
@@ -117,12 +123,14 @@ export function generateCollection(
   options: StrapiCollectionsGeneratorOptions,
   collectionConfig: Partial<StrapiCollection> = {},
 ): CollectionConfig<any> {
-  const { query = {}, collectionName, idGenerator, locale } = collectionConfig;
+  const { query = {}, collectionName, idGenerator, locale, markdown } =
+    collectionConfig;
   const loaderOptions = {
     ...options,
     collectionName,
     idGenerator,
     locale,
+    markdown,
   };
   return defineCollection({
     loader: strapiLoader(contentType, loaderOptions, query),


### PR DESCRIPTION
## Summary
- Opt-in `markdown` on `StrapiLoaderOptions` / `StrapiCollection` with `field`, `getMarkdown`, `includeBody`, and `format: "markdown" | "html"`.
- Helpers: `getValueByPath`, `resolveMarkdownSource`, `createHtmlRenderedContent`, `buildEntryRenderedContent`.
- Uses Astro `LoaderContext.renderMarkdown()` so `render()` / `<Content />` inherit project markdown config.
- Default loader path unchanged when `markdown` is omitted.

Closes #6.

## Test plan
- [x] `yarn tsc --noEmit`
- [x] `yarn test` (119 tests)
- [ ] Smoke in an Astro app: `markdown: { field: 'content' }` + `const { Content } = await render(entry)`
- [ ] Confirm collections without `markdown` behave as before