### PR TITLE
Include Strapi response in errors

### DIFF
--- a/src/utils/__tests__/strapi.test.ts
+++ b/src/utils/__tests__/strapi.test.ts
@@ -54,16 +54,19 @@ describe("Strapi Utils", () => {
     });
 
     it("should throw error on failed request", async () => {
+      const responseText = '{"data":null,"error":{"message":"Content type not found"}}';
+
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         statusText: "Not Found",
+        text: () => Promise.resolve(responseText),
       });
 
       await expect(
         fetchContentTypes({
           url: "http://localhost:1337",
         }),
-      ).rejects.toThrow("Failed to fetch from Strapi: Not Found");
+      ).rejects.toThrow(`Failed to fetch from Strapi: Not Found\nStrapi response: ${responseText}`);
     });
   });
 
@@ -109,6 +112,7 @@ describe("Strapi Utils", () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         statusText: "Not Found",
+        text: () => Promise.resolve(""),
       });
 
       await expect(
@@ -175,6 +179,7 @@ describe("Strapi Utils", () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         statusText: "Unauthorized",
+        text: () => Promise.resolve(""),
       });
 
       await expect(
@@ -276,6 +281,7 @@ describe("Strapi Utils", () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,
         statusText: "Server Error",
+        text: () => Promise.resolve(""),
       });
 
       await expect(
@@ -299,6 +305,7 @@ describe("Strapi Utils", () => {
         .mockResolvedValueOnce({
           ok: false,
           statusText: "Server Error",
+          text: () => Promise.resolve(""),
         });
 
       await expect(

--- a/src/utils/strapi.ts
+++ b/src/utils/strapi.ts
@@ -57,7 +57,8 @@ async function strapiRequest<T>(options: StrapiRequestOptions): Promise<T> {
   });
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch from Strapi: ${response.statusText}`);
+    const responseText = await response.text();
+    throw new Error(`Failed to fetch from Strapi: ${response.statusText}\nStrapi response: ${responseText}`);
   }
 
   return response.json();


### PR DESCRIPTION
# Pull Request

## 📝 Description
This makes it much easier to tell what went wrong when a Strapi request fails. Tests have been changed appropriately, and the test on line 56 of `strapi.test.ts` now tests for the inclusion of the Strapi response in the error.
The Strapi response isn't formatted at all, but I think the inclusion of the entire response is useful.

## 🔄 Changes
- The inclusion of Strapi response text in `strapi.ts`.
- Changes to the tests in `strapi.test.ts` to account for the error changing, and to test for the new error shape.

## 🧪 Testing
Initially I tested by running the tests. I then used the build in my Astro project. Here is the output of an error without this change (the error which initially made me want to make this PR!):
```
00:16:51 [strapi-loader] [pages] Loading data from Strapi...
Failed to fetch from Strapi: Bad Request
  Location:
    /home/quinn/Dev/coinzoom-web/node_modules/@sensinum/astro-strapi-loader/dist/utils/strapi.js:18:15
  Stack trace:
    at strapiRequest (/home/quinn/Dev/coinzoom-web/node_modules/@sensinum/astro-strapi-loader/dist/utils/strapi.js:18:15)
    at async fetchAndStoreData (/home/quinn/Dev/coinzoom-web/node_modules/@sensinum/astro-strapi-loader/dist/utils/loader.js:55:22)
    at async Promise.all (index 0)
    at async run (file:///home/quinn/Dev/coinzoom-web/node_modules/p-queue/dist/index.js:398:36)
```
Here is how the error looks with this change:
```
00:41:51 [strapi-loader] [pages] Loading data from Strapi...
Failed to fetch from Strapi: Bad Request
Strapi response: {"data":null,"error":{"status":400,"name":"ValidationError","message":"Invalid key seo","details":{"key":"seo","path":null,"source":"query","param":"populate"}}}
  Location:
    /home/quinn/Dev/coinzoom-web/node_modules/astro/dist/content/content-layer.js:220:5
  Stack trace:
    at strapiRequest (/home/quinn/Documents/git/astro-strapi-loader/dist/utils/strapi.js:19:15)
    at async fetchAndStoreData (/home/quinn/Documents/git/astro-strapi-loader/dist/utils/loader.js:55:22)
    at async Promise.all (index 0)
    at async run (file:///home/quinn/Dev/coinzoom-web/node_modules/p-queue/dist/index.js:398:36)
```
It is now much more obvious what the issue is.

## ✅ Checklist
- [x] I have read and followed the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My changes follow the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
- [ ] I have added my changes to the [CHANGELOG.md](CHANGELOG.md)
